### PR TITLE
Catch and handle weird r-utils edge case

### DIFF
--- a/workflow/envs/full.yaml
+++ b/workflow/envs/full.yaml
@@ -23,5 +23,5 @@ dependencies:
   - r-tidyr
   - r-mass =7.3.58.1
   - bioconductor-edger =3.36.0
-  - r-r.utils =2.12.3
-  - r-data.table =1.14.10
+  - r-r.utils =2.7.0
+  - r-data.table

--- a/workflow/envs/full.yaml
+++ b/workflow/envs/full.yaml
@@ -16,12 +16,12 @@ dependencies:
   - bcftools = 1.12
   - igvtools =2.3.93
   - bc
-  - r-base
+  - r-base =4.3.1
   - r-optparse =1.7.3
-  - r-dplyr
-  - r-readr
-  - r-tidyr
+  - r-dplyr =1.1.4
+  - r-readr =2.1.5
+  - r-tidyr =1.3.0
   - r-mass =7.3.58.1
   - bioconductor-edger =3.36.0
-  - r-r.utils
-  - r-data.table
+  - r-r.utils =2.12.3
+  - r-data.table =1.14.10

--- a/workflow/envs/full.yaml
+++ b/workflow/envs/full.yaml
@@ -23,5 +23,5 @@ dependencies:
   - r-tidyr
   - r-mass =7.3.58.1
   - bioconductor-edger =3.36.0
-  - r-r.utils =2.7.0
+  - r-r.utils =2.12.0
   - r-data.table

--- a/workflow/envs/full.yaml
+++ b/workflow/envs/full.yaml
@@ -16,11 +16,11 @@ dependencies:
   - bcftools = 1.12
   - igvtools =2.3.93
   - bc
-  - r-base =4.3.1
+  - r-base
   - r-optparse =1.7.3
-  - r-dplyr =1.1.4
-  - r-readr =2.1.5
-  - r-tidyr =1.3.0
+  - r-dplyr
+  - r-readr
+  - r-tidyr
   - r-mass =7.3.58.1
   - bioconductor-edger =3.36.0
   - r-r.utils =2.12.3

--- a/workflow/scripts/merge_features_and_muts.R
+++ b/workflow/scripts/merge_features_and_muts.R
@@ -42,6 +42,17 @@ sample <- paste0("^", opt$sample, "_counts")
 print(paste0("sample is: ", sample))
 
 
+if(!requireNamespace("R.utils", quietly = TRUE)){
+
+  use_readr <- TRUE
+
+}else{
+
+  use_readr <- FALSE
+
+}
+
+
 ### Load mutation counts
 muts_file <- list.files(path = "./results/counts/",
                         pattern = sample,
@@ -62,7 +73,16 @@ if(opt$genes){
   message("genes_file is:")
   print(genes_file)
 
-  genes <- fread(genes_file)
+  if(use_readr){
+
+    genes <- read_csv(genes_file)
+
+
+  }else{
+
+    genes <- fread(genes_file)
+
+  }
   
   colnames(genes) <- c("qname", "status", "nhits", "GF")
   
@@ -88,7 +108,16 @@ if(opt$exons){
   message("exons_file is:")
   print(exons_file)
   
-  exons <- fread(exons_file)
+  if(use_readr){
+
+    exons <- read_csv(exons_file)
+
+
+  }else{
+
+    exons <- fread(exons_file)
+
+  }
   
   colnames(exons) <- c("qname", "status", "nhits", "XF")
   
@@ -110,7 +139,15 @@ if(opt$exonbins){
   exonbins_file <- list.files("./results/featurecounts_exonbins/",
                            pattern = sample, full.names = TRUE)[1]
   
-  exonbins <- fread(exonbins_file)
+  if(use_readr){
+
+    exonbins <- read_csv(exonbins_file)
+
+  }else{
+
+    exonbins <- fread(exonbins_file)
+
+  }
   
   colnames(exonbins) <- c("qname", "status", "nhits", "exon_bin")
   
@@ -135,7 +172,16 @@ if(opt$transcripts){
   transcripts_file <- list.files("./results/featurecounts_transcripts/",
                               pattern = sample, full.names = TRUE)[1]
   
-  transcripts <- fread(transcripts_file)
+  if(use_readr){
+
+    transcripts <- read_csv(transcripts_file)
+
+
+  }else{
+
+    transcripts <- fread(transcripts_file)
+
+  }
   
   colnames(transcripts) <- c("qname", "status", "nhits", "transcripts")
   


### PR DESCRIPTION
One user ran into a case where r-utils seems to have not been installed, leading fread() to fail when trying to load a gzipped file. This could be a bigger conda issue on their end, but there is no reason I can't check for R-utils installation and run read_csv if installation failed.