### PR TITLE
Proper use of setDT

### DIFF
--- a/workflow/scripts/merge_features_and_muts.R
+++ b/workflow/scripts/merge_features_and_muts.R
@@ -61,7 +61,7 @@ muts_file <- list.files(path = "./results/counts/",
 if(use_readr){
 
   muts <- read_csv(muts_file)
-  muts <- setDT(muts)
+  setDT(muts)
 
 
 }else{


### PR DESCRIPTION
Don't need to specify data.table as return of setDT