### PR TITLE
Added and testing gene-level vs. exon-level normalization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - featurecount
-      - develop
   pull_request:
     branches_ignore: []
 

--- a/.test/configs/bam2bakR.yaml
+++ b/.test/configs/bam2bakR.yaml
@@ -68,7 +68,8 @@ features:
   genes: True
   exons: True
 
-
+# Only use exonic reads for normalization? If not, then all reads mapping to annotated genes will be used
+use_exons_only: False
 
 ### Other featureCounts parameters
 # Parameters automatically specified:

--- a/.test/configs/nogenes.yaml
+++ b/.test/configs/nogenes.yaml
@@ -66,7 +66,7 @@ remove_tags: False
   # genes = anywhere in an annotated gene body
   # exons = in exclusively exonic regions of a gene
 features:
-  genes: True
+  genes: False
   exons: True
 
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -59,6 +59,9 @@ spikename: "\"\""
 # If True, tracks will be normalized
 normalize: True
 
+# Only use exonic reads for normalization? If not, then all reads mapping to annotated genes will be used
+use_exons_only: True
+
 # Are you using the Windows subsystem for linux? 0 = Yes, 1 = No
 WSL: 1
 

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -102,7 +102,7 @@ if NORMALIZE:
         shell:
             r"""
             chmod +x {params.rscript}
-            {params.rscript} {extra} --output {output} --spikename {params.spikename} 1> {log} 2>&1
+            {params.rscript} {params.extra} --output {output} --spikename {params.spikename} 1> {log} 2>&1
             """
 
 else:

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -87,23 +87,22 @@ if NORMALIZE:
 
     rule normalize:
         input:
-            expand(
-                "results/featurecounts_exons/{sample}.featureCounts", sample=SAMP_NAMES
-            ),
+            NORMALIZATION_INPUT,
         output:
             "results/normalization/scale",
         log:
             "logs/normalize/normalize.log",
         threads: 1
         params:
-            rscript=workflow.source_path("../scripts/normalize.R"),
+            rscript=workflow.source_path("../scripts/bam2bakR/normalize.R"),
             spikename=config["spikename"],
+            extra=NORMALIZATION_EXTRA,
         conda:
             "../envs/full.yaml"
         shell:
             r"""
             chmod +x {params.rscript}
-            {params.rscript} --dirs ./results/featurecounts_exons/ --output {output} --spikename {params.spikename} 1> {log} 2>&1
+            {params.rscript} {extra} --output {output} --spikename {params.spikename} 1> {log} 2>&1
             """
 
 else:

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -94,7 +94,7 @@ if NORMALIZE:
             "logs/normalize/normalize.log",
         threads: 1
         params:
-            rscript=workflow.source_path("../scripts/bam2bakR/normalize.R"),
+            rscript=workflow.source_path("../scripts/normalize.R"),
             spikename=config["spikename"],
             extra=NORMALIZATION_EXTRA,
         conda:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -142,7 +142,7 @@ else:
 
 # Are exons being used?
 if config.get("use_exons_only", True):
-    NORMALIZATION_EXTRA = "--use_exons_only"
+    NORMALIZATION_EXTRA = ""
 
 else:
-    NORMALIZATION_EXTRA = ""
+    NORMALIZATION_EXTRA = "--use_genes"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -125,3 +125,24 @@ if FORMAT == "PE":
 
 else:
     FC_EXONS_PARAMS = " -R CORE -g gene_id -J"
+
+
+### TRACK NORMALIZATION HELPERS
+
+# What is input for normalization?
+if config.get("use_exons_only", True):
+    NORMALIZATION_INPUT = expand(
+        "results/featurecounts_exons/{sample}.featureCounts", sample=SAMP_NAMES
+    )
+
+else:
+    NORMALIZATION_INPUT = expand(
+        "results/featurecounts_genes/{sample}.featureCounts", sample=SAMP_NAMES
+    )
+
+# Are exons being used?
+if config.get("use_exons_only", True):
+    NORMALIZATION_EXTRA = "--use_exons_only"
+
+else:
+    NORMALIZATION_EXTRA = ""

--- a/workflow/scripts/normalize.R
+++ b/workflow/scripts/normalize.R
@@ -27,11 +27,11 @@ args = commandArgs(trailingOnly = TRUE)
         make_option(c("-e", "--echocode", type="logical"),
                      default = "FALSE",
                      help = 'print R code to stdout'),
-        make_option(c("--use_exons_only"),
+        make_option(c("--use_genes"),
                      action = "store_false",
                      default = TRUE,
                      dest= "exon",
-                     help = 'print R code to stdout'))
+                     help = 'If included, reads from exons and introns will be used for normalization'))
 
     opt_parser <- OptionParser(option_list = option_list)
     opt <- parse_args(opt_parser) # Load options from command line.

--- a/workflow/scripts/normalize.R
+++ b/workflow/scripts/normalize.R
@@ -26,6 +26,11 @@ args = commandArgs(trailingOnly = TRUE)
                     help = 'File to output scale factors to'),
         make_option(c("-e", "--echocode", type="logical"),
                      default = "FALSE",
+                     help = 'print R code to stdout'),
+        make_option(c("--use_exons_only"),
+                     action = "store_false",
+                     default = TRUE,
+                     dest= "exon",
                      help = 'print R code to stdout'))
 
     opt_parser <- OptionParser(option_list = option_list)
@@ -56,7 +61,11 @@ master <- tibble()
 
 
 # Screw it, going to hardcode directory cause I can
-dirs <- paste0(getwd(), "/results/featurecounts_exons/")
+if(opt$exon){
+    dirs <- paste0(getwd(), "/results/featurecounts_exons/")
+}else{
+    dirs <- paste0(getwd(), "/results/featurecounts_genes/")
+}
 
 # Currently will not work alone due to fact that CORE files also have .featureCounts
 samplefiles <- list.files(path = dirs,


### PR DESCRIPTION
Previously, normalization of sequencing tracks could only be done based on exonic read counts. Added a new config parameter that allows users to instead use all gene-mapping reads (exons or introns) for normalization. The parameter is use_exons_only in the config, set to True by default.